### PR TITLE
fix(docs): typo in v11 migration guide title

### DIFF
--- a/website/docs/MigrationV11.md
+++ b/website/docs/MigrationV11.md
@@ -1,6 +1,6 @@
 ---
 id: migration-v11
-title: Migration to 1.0
+title: Migration to 11.0
 ---
 
 Migration to React Native Testing Library version 11 from version 9.x or 10.x should be a relatively easy task due small amount of breaking changes.


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
I believe there is a typo in page title: `Migration to 1.0` should be `Migration to 11.0`

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
<img width="1512" alt="Screen Shot 2022-07-25 at 23 38 22" src="https://user-images.githubusercontent.com/33338165/180818504-1c0369bc-ae84-4b5f-a9f4-d5f4ffe239a8.png">

